### PR TITLE
[WIP] TrackingParticle and SimCluster associationMap producer

### DIFF
--- a/HGCSimTruth/HGCSimTruth/plugins/HGCSimTruth.cc
+++ b/HGCSimTruth/HGCSimTruth/plugins/HGCSimTruth.cc
@@ -567,12 +567,13 @@ void HGCTruthProducer::mergeSimClusters(const SimClusterCollection& simClusters,
     });
 
     // get a vector of all sim tracks, also store the total energy
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float>> combinedmomentum = 0;
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float>> combinedimpact = 0;
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float>> combinedmomentum ;
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<float>> combinedimpact;
     std::vector<SimTrack> mergedSCTracks;
 
     for (const int& iSC : group) {
       // there is currently only one track per sim clusters
+      float E = simClusters[iSC].impactMomentum().E();
       combinedmomentum += simClusters[iSC].impactMomentum();
       combinedimpact += simClusters[iSC].impactPoint() * E;
 

--- a/HGCSimTruth/HGCSimTruth/plugins/TrackingParticleSimClusterAssociationProducer.cc
+++ b/HGCSimTruth/HGCSimTruth/plugins/TrackingParticleSimClusterAssociationProducer.cc
@@ -20,7 +20,7 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include <optional>
+#include <set>
 
 //
 // class decleration
@@ -89,7 +89,6 @@ void TrackingParticleSimClusterAssociationProducer::produce(edm::StreamID, edm::
 
   // NOTE: not every trackingparticle will be in the association.
   // could add empty SCs in this case, but that might be worse...
-  std::cout << "LENGTH OF SIMCLUSTERS IS " << scCollection->size() << std::endl;
   for (size_t i = 0; i < scCollection->size(); i++) {
       SimClusterRef simclus(scCollection, i);
       for (auto tp : findTrackingParticleMatch(trackIdToTPRef, simclus))

--- a/HGCSimTruth/HGCSimTruth/plugins/TrackingParticleSimClusterAssociationProducer.cc
+++ b/HGCSimTruth/HGCSimTruth/plugins/TrackingParticleSimClusterAssociationProducer.cc
@@ -1,0 +1,72 @@
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+//
+// class decleration
+//
+
+typedef edm::AssociationMap<edm::OneToManyWithQuality<
+    TrackingParticleCollection, SimClusterCollection, float>> TrackingParticleToSimCluster;
+
+class TrackingParticleSimClusterAssociationProducer : public edm::global::EDProducer<> {
+public:
+  explicit TrackingParticleSimClusterAssociationProducer(const edm::ParameterSet &);
+  ~TrackingParticleSimClusterAssociationProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<TrackingParticleCollection> tpCollectionToken_;
+  edm::EDGetTokenT<SimClusterCollection> scCollectionToken_;
+};
+
+TrackingParticleSimClusterAssociationProducer::TrackingParticleSimClusterAssociationProducer(const edm::ParameterSet &pset)
+    : tpCollectionToken_(consumes<TrackingParticleCollection>(pset.getParameter<edm::InputTag>("trackingParticles"))),
+        scCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("simClusters")))
+{
+  produces<TrackingParticleToSimCluster>();
+}
+
+TrackingParticleSimClusterAssociationProducer::~TrackingParticleSimClusterAssociationProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void TrackingParticleSimClusterAssociationProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+
+  edm::Handle<TrackingParticleCollection> tpCollection;
+  iEvent.getByToken(tpCollectionToken_, tpCollection);
+
+  edm::Handle<SimClusterCollection> simclusCollection;
+  iEvent.getByToken(scCollectionToken_, simclusCollection);
+
+  auto out = std::make_unique<TrackingParticleToSimCluster>();
+  std::cout << "Trying to make associations\n";
+
+  iEvent.put(std::move(out));
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(TrackingParticleSimClusterAssociationProducer);

--- a/HGCSimTruth/HGCSimTruth/plugins/TrackingParticleSimClusterAssociationProducer.cc
+++ b/HGCSimTruth/HGCSimTruth/plugins/TrackingParticleSimClusterAssociationProducer.cc
@@ -59,10 +59,15 @@ void TrackingParticleSimClusterAssociationProducer::produce(edm::StreamID, edm::
   edm::Handle<TrackingParticleCollection> tpCollection;
   iEvent.getByToken(tpCollectionToken_, tpCollection);
 
-  edm::Handle<SimClusterCollection> simclusCollection;
-  iEvent.getByToken(scCollectionToken_, simclusCollection);
+  edm::Handle<SimClusterCollection> scCollection;
+  iEvent.getByToken(scCollectionToken_, scCollection);
 
-  auto out = std::make_unique<TrackingParticleToSimCluster>();
+  auto out = std::make_unique<TrackingParticleToSimCluster>(tpCollection, scCollection);
+  TrackingParticleRef tp(tpCollection, 0);
+  SimClusterRef sc(scCollection, 0);
+  std::pair<SimClusterRef, float> scVal(sc, 1.);
+  out->insert(tp, scVal);
+
   std::cout << "Trying to make associations\n";
 
   iEvent.put(std::move(out));

--- a/HGCSimTruth/HGCSimTruth/test/testTPtoSCAssociationAlgo.py
+++ b/HGCSimTruth/HGCSimTruth/test/testTPtoSCAssociationAlgo.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+from DataFormats import FWLite
+
+def getGeantTrackIds(obj):
+    geantTracks = obj.g4Tracks()
+    return [t.trackId() for t in geantTracks]
+
+def makeTPtoSCMap(trackingParticles, simClusters):
+    tp_map = {t.g4Tracks().at(0).trackId() : t for t in trackingParticles}
+    tp_map = {}
+    tp_sc_map = {}
+    for tp in trackingParticles:
+        trackIds = getGeantTrackIds(tp)
+        for trackId in trackIds:
+            if trackId in tp_map:
+                print(trackId, tp_map)
+                raise RuntimeError("Found track mapped to multiple tracking particles")
+            tp_map[trackId] = tp
+            tp_sc_map[tp] = []
+
+    for sc in simClusters:
+        trackIds = getGeantTrackIds(sc)
+        for trackId in trackIds:
+            if trackId in tp_map:
+                tp = tp_map[trackId]
+                tp_sc_map[tp].append(sc)
+
+    return tp_sc_map
+
+events = FWLite.Events("test_RECO.root")
+for event in events:
+    tp_handle = FWLite.Handle("std::vector<TrackingParticle>")
+    event.getByLabel("mix:MergedTrackTruth", tp_handle)
+    trackingParticles = tp_handle.product()
+
+    sc_handle = FWLite.Handle("std::vector<SimCluster>")
+    #event.getByLabel("mix:MergedCaloTruth", sc_handle)
+    event.getByLabel("hgcSimTruth", sc_handle)
+    simClusters = sc_handle.product()
+    tp_sc_map = makeTPtoSCMap(trackingParticles, simClusters)
+    print("Length of tracking particles is", len(trackingParticles))
+    print("Length of simClusters is", len(simClusters))
+    print("Length of tp-> sc is", len(tp_sc_map))
+    associated_scs = set()
+    unassociated_tps = set()
+    map(lambda x: associated_scs.update(x), tp_sc_map.values())
+    unassociated_tps = [k for (k,v) in tp_sc_map.iteritems() if not v]
+    multassociated_tps = [k for (k,v) in tp_sc_map.iteritems() if len(v) > 1]
+    print("Number of SCs associated to TPs", len(associated_scs))
+    print("Number of unassociated TPs", len(unassociated_tps))
+    print("Number of TPs associated to multiple SCs", len(multassociated_tps))

--- a/HGCSimTruth/HGCSimTruth/test/testTPtoSCAssociationProd.py
+++ b/HGCSimTruth/HGCSimTruth/test/testTPtoSCAssociationProd.py
@@ -1,0 +1,71 @@
+from __future__ import print_function
+from DataFormats import FWLite
+
+events = FWLite.Events("test_RECO.root")
+#track_handle = FWLite.Handle("std::vector<reco::Track>")
+#events.getByLabel("generalTracks", track_handle)
+#tracks = track_handle.product()
+#t = tracks.at(0)
+#
+#trackAssoc_handle = FWLite.Handle("")
+#events.getByLabel("trackingParticleRecoTrackAsssociation", trackAssoc_handle)
+#trackAssoc = trackAssoc_handle.product()
+#track_handle = FWLite.Handle("std::vector<reco::Track>")
+#events.getByLabel("generalTracks", track_handle)
+#tracks = track_handle.product()
+#t = tracks.at(0)
+
+tp_handle = FWLite.Handle("std::vector<TrackingParticle>")
+events.getByLabel("mix:MergedTrackTruth", tp_handle)
+trackingParticles = tp_handle.product()
+
+sc_handle = FWLite.Handle("std::vector<SimCluster>")
+events.getByLabel("hgcSimTruth", sc_handle)
+simClusters = sc_handle.product()
+events.getByLabel("mix:MergedCaloTruth", sc_handle)
+simClustersUnmerged = sc_handle.product()
+
+tpToSc_handle = FWLite.Handle("edm::AssociationMap<edm::OneToMany<vector<TrackingParticle>,vector<SimCluster>,unsigned int>>")
+events.getByLabel("trackingParticleSimClusterAssociation", tpToSc_handle)
+assoc = tpToSc_handle.product()
+
+tpToScMerged_handle = FWLite.Handle("edm::AssociationMap<edm::OneToMany<vector<TrackingParticle>,vector<SimCluster>,unsigned int>>")
+events.getByLabel("trackingParticleMergedSCAssociation", tpToScMerged_handle)
+mergedAssoc = tpToScMerged_handle.product()
+
+merged_associated_scs = []
+for entry in mergedAssoc:
+    tp = entry.key.get()
+    scs = entry.val
+    print("Size of SCs is", len(scs))
+    
+    print("TP pdgId is", tp.pdgId(), "energy is", tp.energy())
+    for sc in scs:
+        info = (sc.pdgId(), sc.energy(), sc.p())
+        merged_associated_scs.append(info)
+        print("-->Associated SC pdgId is", sc.pdgId(), "energy is", sc.energy())
+
+print("-"*80)
+associated_scs = []
+for entry in assoc:
+    tp = entry.key.get()
+    scs = entry.val
+    
+    print("Size of SCs is", len(scs))
+    
+    print("TP pdgId is", tp.pdgId(), "energy is", tp.energy())
+    for sc in scs:
+        info = (sc.pdgId(), sc.energy(), sc.p())
+        associated_scs.append(info)
+        print("-->Associated SC pdgId is", sc.pdgId(), "energy is", sc.energy())
+
+print("Size of tracking particles is", len(trackingParticles))
+print("Size of merged simClusters is", len(simClusters))
+print("Size of unmerged simClusters is", len(simClustersUnmerged))
+print("Size of trackingParticle --> SimClustersMerged association is", len(mergedAssoc))
+print("Size of trackingParticle --> SimClusters association is", len(assoc))
+print("Number of unique associated merged simClusters is", len(set(merged_associated_scs)))
+print("Number of duplicates was", len(merged_associated_scs)-len(set(merged_associated_scs)))
+print("Number of unqiue associated unmerged simClusters is", len(set(associated_scs)))
+print("Number of duplicates was", len(associated_scs)-len(set(associated_scs)))
+print("> they are", str(set(merged_associated_scs)))

--- a/RecoHGCal/GraphReco/plugins/WindowNTupler.cc
+++ b/RecoHGCal/GraphReco/plugins/WindowNTupler.cc
@@ -88,7 +88,7 @@ class WindowNTupler : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one:
 
       // ----------member data ---------------------------
       edm::EDGetTokenT<std::vector<ticl::Trackster>> tracksters_token_;
-      edm::EDGetTokenT<TrackCollection> tracksToken_;
+      edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
       edm::EDGetTokenT<reco::CaloClusterCollection> layerClustersToken_;
       edm::EDGetTokenT<std::vector<SimCluster>> simClusterToken_;
       std::vector<edm::EDGetTokenT<HGCRecHitCollection> > rechitsTokens_;
@@ -155,7 +155,7 @@ Tracksterwithpos_and_energy WindowNTupler::assignPositionAndEnergy(const ticl::T
 WindowNTupler::WindowNTupler(const edm::ParameterSet& config)
  :
   tracksters_token_(consumes<std::vector<ticl::Trackster>>(config.getParameter<edm::InputTag>("tracksters"))),
-  tracksToken_(consumes<TrackCollection>(config.getParameter<edm::InputTag>("tracks"))),
+  tracksToken_(consumes<edm::View<reco::Track>>(config.getParameter<edm::InputTag>("tracks"))),
   layerClustersToken_(consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusters"))),
   simClusterToken_(consumes<std::vector<SimCluster>>(config.getParameter<edm::InputTag>("simClusters"))),
   //trackingPartToken_(consumes<TrackingParticleCollection>(config.getParameter<edm::InputTag>("trackingParticles"))),

--- a/RecoHGCal/GraphReco/python/windowNTupler_cfi.py
+++ b/RecoHGCal/GraphReco/python/windowNTupler_cfi.py
@@ -25,6 +25,8 @@ WindowNTupler = cms.EDAnalyzer("WindowNTupler",
     layerClusters = cms.InputTag("hgcalLayerClusters"),
     #simClusters = cms.InputTag("mix", "RealisticCaloTruth"),
     simClusters = cms.InputTag("mix", "MergedCaloTruth"),
+    tracksToTrackingParticles = cms.InputTag("trackingParticleRecoTrackAsssociation"),
+    trackingParticleSimCluster = cms.InputTag("trackingParticleSimClusterAssociation"),
     
     removeFrameSimclusters=cms.bool(True),
     

--- a/SimDataFormats/CaloAnalysis/src/classes.h
+++ b/SimDataFormats/CaloAnalysis/src/classes.h
@@ -1,29 +1,14 @@
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/AssociationMapHelpers.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
-namespace SimDataFormats {
-  namespace CaloAnalysis {
-    SimCluster sc;
-    SimClusterCollection vsc;
-    edm::Wrapper<SimClusterCollection> wvsc;
-
-    SimClusterRef scr;
-    SimClusterRefVector scrv;
-    SimClusterRefProd scrp;
-    SimClusterContainer scc;
-
-    SimClusterHistory sch;
-    edm::Wrapper<SimClusterHistory> wsch;
-
-    CaloParticle cp;
-    CaloParticleCollection vcp;
-    edm::Wrapper<CaloParticleCollection> wvcp;
-
-    CaloParticleRef cpr;
-    CaloParticleRefVector cprv;
-    CaloParticleRefProd cprp;
-    CaloParticleContainer cpc;
-  }  // namespace CaloAnalysis
-}  // namespace SimDataFormats
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/OneToManyWithQuality.h"
+#include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"
+#include "DataFormats/Common/interface/View.h"

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -28,5 +28,9 @@
     <field name="transientMap_" transient="true"/>
   </class>
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<TrackingParticle>,std::vector<SimCluster>,float,unsigned int> >>"/>
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<TrackingParticle>,std::vector<SimCluster>,unsigned int> >">
+    <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<TrackingParticle>,std::vector<SimCluster>,unsigned int> >>"/>
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<TrackingParticle> >,edm::RefProd<vector<SimCluster> > >"/>
 </lcgdict>

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -24,4 +24,9 @@
   <class name="SimClusterHistory"/>
   <class name="edm::Wrapper<std::vector<SimClusterHistory>>"/>
   <class name="std::vector<SimClusterHistory>"/>
+  <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<TrackingParticle>,std::vector<SimCluster>,float,unsigned int> >">
+    <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<TrackingParticle>,std::vector<SimCluster>,float,unsigned int> >>"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<TrackingParticle> >,edm::RefProd<vector<SimCluster> > >"/>
 </lcgdict>


### PR DESCRIPTION
Adds a producer to link TrackingParticles to SimCluster

This is still a work in progress because the matching algorithm is very simple at this point. It pairs all tracks and simClusters that share a common SimTrack ID. Outstanding work

* Use SimClusterHistory to see if simcluster simTrack is connected to trackingparticle simTrack by geant history
* Consider if trackingparticle--> simcluster should be unique. 
    * In current implementation, I do not see default unmerged simclusters associated with multiple tracks. With merged simclusters, this happens for up to 50% of the times
* Consider if simcluster --> trackingparticle association map should also be produce
* Add common truth association of trackingparticles and simclusters to ntuples
    * Access reco::track --> trackingparticle via recoToSim associationMap
    * Access trackingparticle -- simcluster via associaitonmap added here
    * If both associations exist, determine ID from trackingparticle+simcluster add a common index
    * Otherwise give both a unique index
